### PR TITLE
feat: improve TOC in coffee machine tutorial

### DIFF
--- a/content/smart-coffee-machine.md
+++ b/content/smart-coffee-machine.md
@@ -9,16 +9,16 @@ draft: false
     <nav id="TableOfContents">
         <h2>Table of Contents</h2>
 		<ul>
-			<li><a href="#api-usage">API usage</a></li>
+			<li><a href="#introduction">Introduction</a></li>
 			<li><a href="#expose-the-thing">Expose the Thing</a></li>
 			<li><a href="#consume-the-thing">Consume the Thing</a></li>
 			<li><a href="#running-scripts-from-node-wot-repository">Running scripts from node-wot repository</a></li>
-			<li><a href="#smart-coffee-machine-and-oauth-20">Smart coffee machine and oAuth 2.0</a></li>
+			<li><a href="#smart-coffee-machine-and-oauth-2-0">Smart coffee machine and oAuth 2.0</a></li>
 		</ul>
     </nav>
 </aside>
 
-## API usage
+## Introduction
 This article is a tutorial which considers a fictional smart coffee machine in order to demonstrate the capabilities of Web of Things (WoT) and the usage of [node-wot API](https://github.com/eclipse/thingweb.node-wot).
 In the world of Web of Thing properties, actions and events provided by a Thing are called Property Affordances, Action Affordances and Event Affordances, respectively.
 The difference of each becomes clear as we proceed the tutorial.


### PR DESCRIPTION
This PR improves 2 things in the coffee machine tutorial:

1. I have realized my local Hugo and the production server differently generate links with dots. So, the production version puts `-` instead of a dot, while my local Hugo server just ignores dots. This PR makes it according to the production server. (Thanks @sebastiankb for spotting the non-working link)
2. @danielpeintner you have added a new TOC term naming it `API usage` but I don't agree with the name. There is actually nothing about API usage in that part, so I have renamed it. Please revise the new name.